### PR TITLE
FIX | Possible false-negative

### DIFF
--- a/cmd/vet-bot/looppointer/looppointer.go
+++ b/cmd/vet-bot/looppointer/looppointer.go
@@ -175,11 +175,9 @@ func (s *Searcher) checkUnaryExpr(n *ast.UnaryExpr, stack []ast.Node, pass *anal
 		if followedBySafeBreak(stack, innermostRangesOverID) {
 			return nil, nil, ReasonNone
 		}
-		if assignStmt.Tok != token.DEFINE {
-			for _, expr := range assignStmt.Rhs {
-				if expr.Pos() == child.Pos() && child.Pos() == n.Pos() {
-					return id, rangeLoop, ReasonPointerReassigned
-				}
+		for _, expr := range assignStmt.Rhs {
+			if expr.Pos() == child.Pos() && child.Pos() == n.Pos() {
+				return id, rangeLoop, ReasonPointerReassigned
 			}
 		}
 		return nil, nil, ReasonNone

--- a/kubernetes/deployments.yml
+++ b/kubernetes/deployments.yml
@@ -25,7 +25,7 @@ spec:
           - name: EXPERTS_FILE
             value: /config/experts.csv
           - name: GITHUB_REPO
-            value: kalexmills/github-vet-tests-dec2020
+            value: github-vet/rangeloop-pointer-findings
         envFrom:
           - secretRef:
               name: github-vet-secrets
@@ -44,9 +44,11 @@ spec:
           # - name: REPOS_FILE
           #   value: /data/repos.csv
           - name: VISITED_FILE
-            value: /data/gophers.csv
+            value: /data/visited_repos.csv
           - name: GITHUB_REPO
-            value: kalexmills/github-vet-tests-dec2020
+            value: github-vet/rangeloop-pointer-findings
+          - name: ACCEPT_LIST_FILE
+            value: /config/accept.yml
         envFrom:
           - secretRef:
               name: github-vet-secrets
@@ -54,13 +56,18 @@ spec:
           - name: botspace
             mountPath: /data
             subPath: data/vetbot
+          - name: acceptlist
+            mountPath: /config
       volumes:
         - name: botspace
           persistentVolumeClaim:
               claimName: github-vet-bot-storage
         - name: experts
           configMap:
-              name: github-vet-bot-experts
+              name: github-track-bot-experts
+        - name: acceptlist
+          configMap:
+              name: github-vet-bot-acceptlist
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/kubernetes/experts.yml
+++ b/kubernetes/experts.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: github-vet-bot-experts
+  name: github-track-bot-experts
 data:
   experts.csv: |
     kalexmills,0


### PR DESCRIPTION
We cannot restrict the reassignment check to the `=` operator unless we also do some name resolution. Since we're not, we have to report on both `:=` and `=` reassignments.