### PR TITLE
FIX | bug in UpdateCommunityAssessment

### DIFF
--- a/cmd/track-bot/main.go
+++ b/cmd/track-bot/main.go
@@ -231,7 +231,7 @@ func UpdateCommunityAssessment(bot *TrackBot, record *Issue, issue *github.Issue
 	maxScore := float32(0)
 	var maxOutcome string
 	for outcome, score := range scores {
-		if score > CommunityScoreThreshold && score > maxScore {
+		if score >= CommunityScoreThreshold && score > maxScore {
 			maxScore = score
 			maxOutcome = outcome
 		}


### PR DESCRIPTION
Community assessment labels should be applied even when the threshold is exactly met.