### PR TITLE
Include callgraph paths for functions writing pointers; fix nefarious bug yielding false-negatives

### DIFF
--- a/cmd/vet-bot/callgraph/analyzer.go
+++ b/cmd/vet-bot/callgraph/analyzer.go
@@ -153,3 +153,8 @@ func SignatureFromCallExpr(call *ast.CallExpr) Signature {
 	}
 	return result
 }
+
+// SignatureFromFuncDecl retrieves a signature from the provided FuncDecl.
+func SignatureFromFuncDecl(fdec *ast.FuncDecl) Signature {
+	return parseSignature(fdec).Signature
+}

--- a/cmd/vet-bot/callgraph/callgraph.go
+++ b/cmd/vet-bot/callgraph/callgraph.go
@@ -24,15 +24,8 @@ type CallGraph struct {
 func resultToCallGraph(r Result) CallGraph {
 	result := NewCallGraph()
 	for _, call := range r.Calls {
-		callerSig := call.Caller.Signature
-		callerID, ok := result.signatureToId[callerSig]
-		if !ok {
-			callerID = result.AddSignature(callerSig)
-		}
-		callID, ok := result.signatureToId[call.Signature]
-		if !ok {
-			callID = result.AddSignature(call.Signature)
-		}
+		callerID := result.AddSignature(call.Caller.Signature)
+		callID := result.AddSignature(call.Signature)
 		result.AddCall(callerID, callID)
 	}
 	return result
@@ -49,6 +42,9 @@ func NewCallGraph() CallGraph {
 // AddSignature adds a new signature to the callgraph and returns an ID that can
 // later be used to refer to it.
 func (cg *CallGraph) AddSignature(sig Signature) int {
+	if id, ok := cg.signatureToId[sig]; ok {
+		return id
+	}
 	id := len(cg.signatures)
 	cg.signatures = append(cg.signatures, sig)
 	cg.signatureToId[sig] = id

--- a/cmd/vet-bot/callgraph/callgraph.go
+++ b/cmd/vet-bot/callgraph/callgraph.go
@@ -2,6 +2,7 @@ package callgraph
 
 import (
 	"errors"
+	"sync"
 )
 
 // CallGraph represents an approximate call-graph, relying only on the name and arity of each function.
@@ -19,6 +20,7 @@ type CallGraph struct {
 	signatureToId map[Signature]int
 	callGraph     map[int][]int
 	calledByGraph map[int][]int // lazily-constructed
+	mut           sync.Mutex
 }
 
 func resultToCallGraph(r Result) CallGraph {
@@ -146,6 +148,8 @@ func (cg *CallGraph) BFSWithStack(root Signature, visit func(sig Signature, stac
 // lazyInitCalledBy initializes the calledByGraph structure if it is nil. Not all applications will require
 // this graph, so it is constructed on-demand.
 func (cg *CallGraph) lazyInitCalledBy() {
+	cg.mut.Lock()
+	defer cg.mut.Unlock()
 	if cg.calledByGraph != nil {
 		return
 	}

--- a/cmd/vet-bot/looppointer/looppointer.go
+++ b/cmd/vet-bot/looppointer/looppointer.go
@@ -204,7 +204,7 @@ func (s *Searcher) checkUnaryExpr(n *ast.UnaryExpr, stack []ast.Node, pass *anal
 
 	sig := callgraph.SignatureFromCallExpr(callExpr)
 	if _, ok := syncFuncs[sig]; !ok {
-		reportAsyncSuspicion(pass, rangeLoop, ReasonCallMaybeAsync, callExpr, id)
+		reportAsyncSuspicion(pass, rangeLoop, callExpr, id)
 		return ReasonCallMaybeAsync
 	}
 	callIdx := -1
@@ -226,32 +226,66 @@ func (s *Searcher) checkUnaryExpr(n *ast.UnaryExpr, stack []ast.Node, pass *anal
 	return ReasonCallMayWritePtr
 }
 
-func reportAsyncSuspicion(pass *analysis.Pass, rangeLoop *ast.RangeStmt, reason Reason, call *ast.CallExpr, id *ast.Ident) {
-	startsGoroutine := pass.ResultOf[nogofunc.Analyzer].(*nogofunc.Result).ContainsGoStmt
-	cg := pass.ResultOf[callgraph.Analyzer].(*callgraph.Result).ApproxCallGraph
+// reportWritePtrSuspicion validates the suspicion and also reports the finding that a function may write a
+// pointer.
+func reportWritePtrSuspicion(pass *analysis.Pass, rangeLoop *ast.RangeStmt, call *ast.CallExpr, id *ast.Ident) {
+	dangerGraph := pass.ResultOf[pointerescapes.Analyzer].(*pointerescapes.Result).DangerGraph
+	writesPtr := pass.ResultOf[pointerescapes.Analyzer].(*pointerescapes.Result).WritesPtr
+
 	sig := callgraph.SignatureFromCallExpr(call)
 	paths := make(map[string]struct{})
+
+	err := dangerGraph.BFSWithStack(sig, func(sig callgraph.Signature, stack []callgraph.Signature) {
+		if _, ok := writesPtr[sig]; ok {
+			paths[writePath(stack)] = struct{}{}
+		}
+	})
+
+	if err == callgraph.ErrSignatureMissing {
+		log.Printf("could not find root signature %v in callgraph; 3rd-party code suspected", sig)
+	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     rangeLoop.Pos(),
+		End:     rangeLoop.End(),
+		Message: ReasonCallMaybeAsync.Message(id.Name, pass.Fset.Position(id.Pos())),
+
+		Related: []analysis.RelatedInformation{
+			{Message: pass.Fset.File(call.Pos()).Name()},
+			{Message: reportPaths(paths, "function which writes a pointer argument")},
+		},
+	})
+}
+
+// reportAsyncSuspicion validates the suspicion and also reports the finding that a function may lead to starting
+// a goroutine.
+func reportAsyncSuspicion(pass *analysis.Pass, rangeLoop *ast.RangeStmt, call *ast.CallExpr, id *ast.Ident) {
+	// TODO: this also must report whenever a noted "third-party" signature is reached in the callgraph.
+	startsGoroutine := pass.ResultOf[nogofunc.Analyzer].(*nogofunc.Result).ContainsGoStmt
+	cg := pass.ResultOf[callgraph.Analyzer].(*callgraph.Result).ApproxCallGraph
+
+	sig := callgraph.SignatureFromCallExpr(call)
+	paths := make(map[string]struct{})
+
 	err := cg.BFSWithStack(sig, func(sig callgraph.Signature, stack []callgraph.Signature) {
 		if _, ok := startsGoroutine[sig]; ok {
 			paths[writePath(stack)] = struct{}{}
 		}
 	})
+
 	if err == callgraph.ErrSignatureMissing {
 		log.Printf("could not find root signature %v in callgraph; 3rd-party code suspected", sig)
-		// TODO?: report possible third-party code
+		// TODO?: report possible third-party code?
 	}
-	if len(paths) == 0 {
-		log.Printf("async suspicion found at %s was not supported by evidence", pass.Fset.Position(call.Pos()).String())
-		return
-	}
+
 	pass.Report(analysis.Diagnostic{
 		Pos:     rangeLoop.Pos(),
 		End:     rangeLoop.End(),
-		Message: reason.Message(id.Name, pass.Fset.Position(id.Pos())),
+		Message: ReasonCallMaybeAsync.Message(id.Name, pass.Fset.Position(id.Pos())),
 
 		Related: []analysis.RelatedInformation{
 			{Message: pass.Fset.File(call.Pos()).Name()},
-			{Message: reportPaths(paths)},
+			{Message: reportPaths(paths, "function calling a goroutine")},
 		},
 	})
 }
@@ -267,11 +301,16 @@ func writePath(signatures []callgraph.Signature) string {
 	return sb.String()
 }
 
-func reportPaths(paths map[string]struct{}) string {
+func reportPaths(paths map[string]struct{}, badFuncPhrase string) string {
 	var sb strings.Builder
-	sb.WriteString("The following paths through the callgraph could lead to a goroutine:\n")
+	sb.WriteString("The following paths through the callgraph could lead to a ")
+	sb.WriteString(badFuncPhrase)
+	sb.WriteString(":\n")
 	for path := range paths {
 		fmt.Fprintf(&sb, "\t%v\n", path)
+	}
+	if len(paths) == 0 {
+		sb.WriteString("\tno paths found; call ended in third-party code; stay tuned for diagnostics")
 	}
 	return sb.String()
 }

--- a/cmd/vet-bot/looppointer/looppointer.go
+++ b/cmd/vet-bot/looppointer/looppointer.go
@@ -222,7 +222,7 @@ func (s *Searcher) checkUnaryExpr(n *ast.UnaryExpr, stack []ast.Node, pass *anal
 			return ReasonNone
 		}
 	}
-	reportBasic(pass, rangeLoop, ReasonCallMayWritePtr, n, id)
+	reportWritePtrSuspicion(pass, rangeLoop, callExpr, id)
 	return ReasonCallMayWritePtr
 }
 
@@ -242,13 +242,13 @@ func reportWritePtrSuspicion(pass *analysis.Pass, rangeLoop *ast.RangeStmt, call
 	})
 
 	if err == callgraph.ErrSignatureMissing {
-		log.Printf("could not find root signature %v in callgraph; 3rd-party code suspected", sig)
+		// TODO: this is tripping during the devtest. Need to understand why.
+		log.Printf("writeptr: could not find root signature %v in callgraph; 3rd-party code suspected", sig)
 	}
-
 	pass.Report(analysis.Diagnostic{
 		Pos:     rangeLoop.Pos(),
 		End:     rangeLoop.End(),
-		Message: ReasonCallMaybeAsync.Message(id.Name, pass.Fset.Position(id.Pos())),
+		Message: ReasonCallMayWritePtr.Message(id.Name, pass.Fset.Position(id.Pos())),
 
 		Related: []analysis.RelatedInformation{
 			{Message: pass.Fset.File(call.Pos()).Name()},
@@ -274,7 +274,7 @@ func reportAsyncSuspicion(pass *analysis.Pass, rangeLoop *ast.RangeStmt, call *a
 	})
 
 	if err == callgraph.ErrSignatureMissing {
-		log.Printf("could not find root signature %v in callgraph; 3rd-party code suspected", sig)
+		log.Printf("async: could not find root signature %v in callgraph; 3rd-party code suspected", sig)
 		// TODO?: report possible third-party code?
 	}
 

--- a/cmd/vet-bot/looppointer/testdata/src/devtest/devtest.go
+++ b/cmd/vet-bot/looppointer/testdata/src/devtest/devtest.go
@@ -1,12 +1,24 @@
 package main
 
+import "fmt"
+
 func main() {
 	var a A
-	for _, x := range []int{1} {
-		a.foo3(&x, &x)
+	for _, z := range []int{1} { // want `function call at line 9 may store a reference to z`
+		var y int
+		a.unsafeWrites(&z, &y)
 	}
-	for _, x := range []int{1} { // want `function call which takes a reference to x at line 9 may start a goroutine`
-		bar(&x)
+	for _, x := range []int{1, 2} { // want `function call which takes a reference to x at line 12 may start a goroutine`
+		unsafeAsync(&x)
+	}
+	for _, x := range []int{1, 2} {
+		a.safe("hello", &x)
+	}
+	for _, x := range []int{1, 2, 3, 4} { // want `function call at line 18 may store a reference to x`
+		unsafeCallsAWrite(a, &x)
+	}
+	for _, y := range []int{1} { // want `function call at line 21 may store a reference to y`
+		unsafeCallsAWriteViaPointerLabyrinth(&y)
 	}
 }
 
@@ -16,44 +28,77 @@ type B struct {
 	a A
 }
 
-func (b *B) foo() {
-	b.a.foo2(2)
+func (b *B) unsafeWritesNoArgs() {
+	b.a.unsafeAsyncToWrite(2)
 }
 
-func (a *A) foo() {
+func (a *A) veryUnsafeNoArgs() {
 	var x, y int
 	z := a
-	z.foo2(x)
+	z.unsafeAsyncToWrite(x)
 
-	a.foo3(&x, &y)
-	a.foo4("1", &x)
-	bar(&x)
-	bar(&x)
+	a.unsafeWrites(&x, &y)
+	a.safe("1", &x)
+	unsafeAsync(&x)
+	unsafeAsync(&x)
 }
 
-func (a *A) foo2(x int) {
-	go a.foo3(&x, &x)
+func (a *A) unsafeAsyncToWrite(x int) {
+	go a.unsafeWrites(&x, &x)
 }
 
-func (a *A) foo3(x, y *int) *int {
+func (a *A) unsafeWrites(x, y *int) *int {
+	return struct {
+		x, y *int
+	}{x, y}.x // why not?
+}
+
+func (a *A) safe(x string, y *int) *int {
 	return nil
 }
 
-func (a *A) foo4(x string, y *int) *int {
-	return nil
+func unsafeCallsAWrite(a A, x *int) {
+	a.unsafeWrites(x, x)
 }
 
-func bar(x *int) {
-	bar1(x)
+func unsafeAsync(x *int) {
+	unsafeAsync1(x)
 }
-func bar1(x *int) {
-	bar2(x)
+func unsafeAsync1(x *int) {
+	unsafeAsync2(x)
 }
-func bar2(x *int) {
-	bar3(x)
+func unsafeAsync2(x *int) {
+	unsafeAsync3(x)
 }
-func bar3(x *int) {
+func unsafeAsync3(x *int) {
 	go func() {
 
 	}()
+}
+
+func unsafeCallsAWriteViaPointerLabyrinth(x *int) {
+	labyrinth1(3, "hello", x, 4.0)
+}
+
+func labyrinth1(x int, y string, z *int, w float32) { // z unsafe
+	forPtr := 3
+	labyrinth2(y, z, &forPtr)
+}
+
+func labyrinth2(y string, z *int, w *int) { // z unsafe
+	labyrinth3(w, z, w)
+}
+
+func labyrinth3(x *int, z *int, y *int) {
+	labyrinth4(z, x, y)
+}
+
+func labyrinth4(z *int, x *int, y *int) {
+	writePtr(z)
+} // okay so it's only a tiny labyrinth... :shrug:
+
+func writePtr(x *int) {
+	var y *int
+	y = x // 'write' is triggered here
+	fmt.Println(y)
 }

--- a/cmd/vet-bot/nogofunc/nogofunc.go
+++ b/cmd/vet-bot/nogofunc/nogofunc.go
@@ -45,6 +45,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		(*ast.GoStmt)(nil),
 	}
 
+	// nogofunc finds a list of functions declared in the target repository which don't start any
+	// goroutines on their own. Calling into third-party code can be ignored
 	sigByPos := make(map[token.Pos]*signatureFacts)
 	for _, sig := range graph.Signatures {
 		sigByPos[sig.Pos] = &signatureFacts{sig, false}


### PR DESCRIPTION
There's a substantial bug yielding false-negatives fixed in this PR. We may see the number of instances found jump significantly after it's merged.