### PR TITLE
looppointer reports suspicious callgraphs using graphviz DOT format.

### DIFF
--- a/kubernetes/acceptlist.yml
+++ b/kubernetes/acceptlist.yml
@@ -39,4 +39,9 @@ data:
         - ServeFile
         - SetCookie
         - ProxyURL
+      reflect:
+        - ValueOf
+        - TypeOf
+        - Swapper
+        - DeepEqual
 


### PR DESCRIPTION
This should be better for extremely large suspicion graphs.

A further step would include the source positions where the function declarations were found in the graph. One UX issue with doing that; they wouldn't be copy-pastable from the image (obviously).

It might be better to just include a table mapping from the `{signature arity}` format to links to source locations where matching declarations were found.